### PR TITLE
Auto CharSet for links

### DIFF
--- a/OneDriveBully/SymbolicLink.cs
+++ b/OneDriveBully/SymbolicLink.cs
@@ -47,7 +47,7 @@ namespace OneDriveBully
 
         private const int targetIsADirectory = 1;
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         private static extern SafeFileHandle CreateFile(
             string lpFileName,
             uint dwDesiredAccess,
@@ -57,7 +57,7 @@ namespace OneDriveBully
             uint dwFlagsAndAttributes,
             IntPtr hTemplateFile);
 
-        [DllImport("kernel32.dll", SetLastError = true)]
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         static extern bool CreateSymbolicLink(string lpSymlinkFileName, string lpTargetFileName, int dwFlags);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]


### PR DESCRIPTION
Having a link with Greek letters was causing a System.IO.FileNotFoundException: 'The filename, directory name, or volume label syntax is incorrect. (Exception from HRESULT: 0x8007007B)'

`DllImport("kernel32.dll")` is unable to handle a path like "C:\\OneDrive\Γραφείο". Adding `CharSet = CharSet.Auto` (like `DeviceIoControl`) fixes the problem

`[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]`

[MSDN SafeFileHandle Class](https://docs.microsoft.com/en-us/dotnet/api/microsoft.win32.safehandles.safefilehandle#examples)